### PR TITLE
Remove `npx only-allow pnpm` preinstall step

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "lint:prettier": "prettier --config=.prettierrc --ignore-path=.prettierignore --check '**/*.{ts,tsx,gql,js}'",
     "test": "vitest",
     "changeset": "changeset",
-    "release": "npm whoami && npm run build && changeset publish",
-    "preinstall": "npx only-allow pnpm"
+    "release": "npm whoami && npm run build && changeset publish"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
This appears to be blocking our CI deploys as we use `npm`. The issue seems to be similar to this one: https://github.com/faker-js/faker/issues/290

Any chance you can remove this step?